### PR TITLE
feat(api): PUT /edp/me — cliente actualiza su propio perfil

### DIFF
--- a/app/Http/Controllers/Api/UsuarioApiController.php
+++ b/app/Http/Controllers/Api/UsuarioApiController.php
@@ -93,4 +93,73 @@ class UsuarioApiController extends Controller
             'message' => 'Sesión cerrada correctamente',
         ]);
     }
+
+    /**
+     * Actualizar los datos del usuario autenticado.
+     *
+     * - Cambios "livianos" (nombre, apellido, género) no piden password.
+     * - Cambios "sensibles" (email, contraseña) requieren `password_actual`
+     *   correcta. Esto evita que alguien que dejó el SPA abierto y se
+     *   levantó del escritorio termine con su cuenta capturada.
+     *
+     * PUT /edp/me  (auth:sanctum)
+     */
+    public function updateMe(Request $request)
+    {
+        $usuario = $request->user();
+
+        $data = $request->validate([
+            'nombre'         => 'sometimes|required|string|max:255',
+            'apellido'       => 'sometimes|required|string|max:255',
+            'genero'         => 'sometimes|nullable|in:M,F,O',
+            'email'          => 'sometimes|required|email|unique:usuarios,email,' . $usuario->id,
+            'password'       => [
+                'sometimes',
+                'required',
+                'confirmed',
+                Password::min(8)->letters()->mixedCase()->numbers()->symbols(),
+            ],
+            // Solo lo exigimos cuando se quiere cambiar email o password.
+            'password_actual' => 'required_with:email,password|string',
+        ], [
+            'password_actual.required_with' => 'Necesitás tu contraseña actual para cambiar el email o la contraseña.',
+        ]);
+
+        // Verificar la contraseña actual si se está cambiando email o password.
+        $cambiaEmail    = $request->has('email')    && $request->email    !== $usuario->email;
+        $cambiaPassword = $request->has('password') && $request->password !== null;
+
+        if (($cambiaEmail || $cambiaPassword) && ! Hash::check($request->password_actual, $usuario->password)) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'password_actual' => ['La contraseña actual no es correcta.'],
+            ]);
+        }
+
+        // Armar el set de cambios. Nunca permitimos que el cliente edite su
+        // propio rol desde este endpoint — eso lo hace solo el admin desde
+        // el backoffice (UsuarioController::update).
+        $changes = [];
+        foreach (['nombre', 'apellido', 'genero', 'email'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $changes[$field] = $data[$field];
+            }
+        }
+        if (! empty($data['password'] ?? null)) {
+            $changes['password'] = Hash::make($data['password']);
+        }
+        // Si se cambia el email, mantenemos username == email para no
+        // dejar inconsistencias (el username se setea así al registrarse).
+        if (isset($changes['email'])) {
+            $changes['username'] = $changes['email'];
+        }
+
+        if (! empty($changes)) {
+            $usuario->update($changes);
+        }
+
+        return response()->json([
+            'usuario' => $usuario->fresh(),
+            'message' => 'Perfil actualizado correctamente',
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,6 +59,9 @@ Route::post('/login', [UsuarioApiController::class, 'login']);
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [UsuarioApiController::class, 'logout']);
     Route::get('/user', [UsuarioApiController::class, 'me']);
+    // Edición del propio perfil. Cambios sensibles (email, password)
+    // requieren password_actual en el body.
+    Route::put('/me', [UsuarioApiController::class, 'updateMe']);
 
     // Historial de ventas del usuario logueado. Diferente de
     // /ventas/cliente/{email} (público), este solo devuelve las propias.


### PR DESCRIPTION
Endpoint para que el cliente (logueado via Sanctum) actualice sus datos desde el SPA. Soporta cambios parciales (sometimes en cada campo).

UsuarioApiController::updateMe
- nombre, apellido, genero: cambios livianos, no piden password.
- email, password: cambios sensibles, requieren 'password_actual' en el body. Sin esa verificacion alguien que dejo el SPA abierto en una pc compartida podria perder su cuenta.
- Si cambia el email, tambien actualizamos el username (se mantiene el invariante username == email del flujo de registro).
- NUNCA permitimos editar el rol desde aca. Eso queda solo para el admin via UsuarioController::update.
- email validado como unique excluyendo el propio usuario.
- password con la misma policy fuerte que en registro (8+ chars, may/min/numero/simbolo) y confirmed.
- Devuelve el usuario actualizado para que el frontend refresque su localStorage.

routes/api.php
- PUT /me dentro del grupo auth:sanctum existente.